### PR TITLE
Fix typo for Initalize method

### DIFF
--- a/AsteroidsGame/GameComponents/GameManager.cs
+++ b/AsteroidsGame/GameComponents/GameManager.cs
@@ -20,10 +20,10 @@ namespace Asteroids.GameComponents
         public GameManager(IHubContext<GameHub> gameHub)
         {
             _hubContext = gameHub;
-            Initialzie();
+            Initialize();
         }
 
-        public void Initialzie()
+        public void Initialize()
         {
             _game = new Game(_width, _height);
             _game.State = GameState.Running;

--- a/AsteroidsGame/Hubs/GameHub.cs
+++ b/AsteroidsGame/Hubs/GameHub.cs
@@ -43,7 +43,7 @@ namespace Asteroids.Hubs
 
         public async Task RestartGame()
         {
-            _game.Initialzie();
+            _game.Initialize();
         }
 
         public async Task KeyDown(string key, int keyCode)


### PR DESCRIPTION
Fixing a small typo in the Initialize method name. 